### PR TITLE
Reserve space upfront

### DIFF
--- a/include/FSFILE.h
+++ b/include/FSFILE.h
@@ -23,12 +23,14 @@ bool FSFILE_Delete(FsFileSystem *filesystem, const char *path);
 /// failure.
 /// @param filesystem Filesystem to open the file from.
 /// @param filePath Path to open.
+/// @param CREATING_SIZE How much space reserve for file upfront.
 FSFILE *FSFILE_Open(FsFileSystem *filesystem, const char *path, int64_t CREATING_SIZE);
 
 /// @brief Attempts to write the buffer to the FSFILE passed.
 /// @param file File to write to.FSFILE *file,
 /// @param buffer Buffer to write.
 /// @param size Size of the buffer to write.
+/// @param resize Resize file before writing.
 /// @return Bytes written on success. -1 on failure.
 ssize_t FSFILE_Write(FSFILE *file, void *buffer, size_t size, bool resize);
 

--- a/include/FSFILE.h
+++ b/include/FSFILE.h
@@ -23,14 +23,19 @@ bool FSFILE_Delete(FsFileSystem *filesystem, const char *path);
 /// failure.
 /// @param filesystem Filesystem to open the file from.
 /// @param filePath Path to open.
-FSFILE *FSFILE_Open(FsFileSystem *filesystem, const char *path);
+FSFILE *FSFILE_Open(FsFileSystem *filesystem, const char *path, int64_t CREATING_SIZE);
 
 /// @brief Attempts to write the buffer to the FSFILE passed.
 /// @param file File to write to.FSFILE *file,
 /// @param buffer Buffer to write.
 /// @param size Size of the buffer to write.
 /// @return Bytes written on success. -1 on failure.
-ssize_t FSFILE_Write(FSFILE *file, void *buffer, size_t size);
+ssize_t FSFILE_Write(FSFILE *file, void *buffer, size_t size, bool resize);
+
+/// @brief Attempts to resize file to offset stored in FSFILE.
+/// @param file File to resize;
+/// @return True on success. False on failure.
+bool FSFILE_Resize(FSFILE *file);
 
 /// @brief Flushes the file passed.
 /// @param file File to flush.

--- a/source/FSFILE.c
+++ b/source/FSFILE.c
@@ -69,7 +69,7 @@ cleanup:
 }
 
 bool FSFILE_Resize(FSFILE *file) {
-    return R_FAILED(fsFileSetSize(&file->handle, file->offset));
+    return R_SUCCEEDED(fsFileSetSize(&file->handle, file->offset));
 }
 
 ssize_t FSFILE_Write(FSFILE *file, void *buffer, size_t size, bool resize)

--- a/source/FSFILE.c
+++ b/source/FSFILE.c
@@ -32,10 +32,9 @@ bool FSFILE_Delete(FsFileSystem *filesystem, const char *path)
     return R_SUCCEEDED(fsFsDeleteFile(filesystem, path));
 }
 
-FSFILE *FSFILE_Open(FsFileSystem *filesystem, const char *path)
+FSFILE *FSFILE_Open(FsFileSystem *filesystem, const char *path, int64_t CREATING_SIZE)
 {
     // Both of these are zero to start since we don't have any idea what the ending PNG size will be.
-    static const int64_t CREATING_SIZE    = 0;
     static const uint32_t CREATING_OPTION = 0;
 
     // Check if it exists. If it doesn't create it.
@@ -69,15 +68,21 @@ cleanup:
     return NULL;
 }
 
-ssize_t FSFILE_Write(FSFILE *file, void *buffer, size_t size)
+bool FSFILE_Resize(FSFILE *file) {
+    return R_FAILED(fsFileSetSize(&file->handle, file->offset));
+}
+
+ssize_t FSFILE_Write(FSFILE *file, void *buffer, size_t size, bool resize)
 {
     // Do not continue if we're not passed valid data.
     if (!file || !buffer) { return -1; }
 
-    // Update the size of the file.
-    const int64_t newSize = file->offset + size;
-    const bool sizeError  = R_FAILED(fsFileSetSize(&file->handle, newSize));
-    if (sizeError) { return -1; }
+    if (resize) {
+        // Update the size of the file.
+        const int64_t newSize = file->offset + size;
+        const bool sizeError  = R_FAILED(fsFileSetSize(&file->handle, newSize));
+        if (sizeError) { return -1; }
+    }
 
     // Attempt to write the data.
     const bool writeError = R_FAILED(fsFileWrite(&file->handle, file->offset, buffer, size, FsWriteOption_None));

--- a/source/png_capture.c
+++ b/source/png_capture.c
@@ -75,7 +75,7 @@ void png_capture(FsFileSystem *filesystem)
     else if (!png_init_structs(&writeStruct, &infoStruct)) { return; }
 
     // Attempt to open temporary output file.
-    pngFile = FSFILE_Open(filesystem, TEMPORARY_NAME);
+    pngFile = FSFILE_Open(filesystem, TEMPORARY_NAME, 1024*1024*3);
     if (!pngFile) { goto cleanup; }
 
     // Initialize libpng to use our write functions and write the initial info.
@@ -98,6 +98,7 @@ void png_capture(FsFileSystem *filesystem)
 cleanup:
     // This will finalize writing and destroy the structs.
     png_cleanup(&writeStruct, &infoStruct);
+    FSFILE_Resize(pngFile);
     FSFILE_Close(pngFile);
     capsscCloseRawScreenShotReadStream();
 
@@ -117,7 +118,7 @@ cleanup:
 static void png_write_function(png_structp writingStruct, png_bytep pngData, png_size_t length)
 {
     FSFILE *fsfile = (FSFILE *)png_get_io_ptr(writingStruct);
-    FSFILE_Write(fsfile, pngData, length);
+    FSFILE_Write(fsfile, pngData, length, false);
 }
 
 static void png_flush_function(png_structp writingStruct)


### PR DESCRIPTION
This reduces time of making screenshot file from 3 to 6x depending on compression level (now level 0 takes less than 1 second to save, level 4 takes in worst case around 1.5s)

Reserves 3MiB upfront and before closing space is reduced to match expected size.